### PR TITLE
Bump dependencies for atomic optimistic lock support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,10 @@
     "require": {
         "php": "^8.3",
         "gember/event-sourcing": "^0.14",
-        "gember/identity-generator-symfony": "^0.11",
-        "gember/message-bus-symfony": "^0.11",
+        "gember/identity-generator-symfony": "^0.12",
+        "gember/message-bus-symfony": "^0.12",
         "gember/rdbms-event-store-doctrine-dbal": "^0.12",
-        "gember/serializer-symfony": "^0.11",
+        "gember/serializer-symfony": "^0.12",
         "symfony/config": "^7.1|^7.2|^8.0",
         "symfony/console": "^7.1|^7.2|^8.0",
         "symfony/dependency-injection": "^7.1|^7.2|^8.0",

--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,10 @@
     ],
     "require": {
         "php": "^8.3",
-        "gember/event-sourcing": "^0.13",
+        "gember/event-sourcing": "^0.14",
         "gember/identity-generator-symfony": "^0.11",
         "gember/message-bus-symfony": "^0.11",
-        "gember/rdbms-event-store-doctrine-dbal":  "^0.11",
+        "gember/rdbms-event-store-doctrine-dbal": "^0.12",
         "gember/serializer-symfony": "^0.11",
         "symfony/config": "^7.1|^7.2|^8.0",
         "symfony/console": "^7.1|^7.2|^8.0",


### PR DESCRIPTION
Bumps `gember/event-sourcing` to `^0.14` and `gember/rdbms-event-store-doctrine-dbal` to `^0.12` to pick up the atomic optimistic lock changes introduced in `gember/dependency-contracts` 0.4.

These releases fix a TOCTOU race condition in the event store's optimistic lock guard by merging the check and write into a single atomic `saveEvents()` call with `SELECT ... FOR UPDATE`.

## Breaking changes

None — this is a dependency version bump only. No code changes in the bundle itself.