### PR TITLE
Add outbox dispatch strategy and processor command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /bin-dev/
 /var/
 /vendor/
+composer.lock

--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -12,4 +12,5 @@ return $config
     ->ignoreErrorsOnPackage('gember/message-bus-symfony', [ErrorType::UNUSED_DEPENDENCY])
     ->ignoreErrorsOnPackage('gember/rdbms-event-store-doctrine-dbal', [ErrorType::UNUSED_DEPENDENCY])
     ->ignoreErrorsOnPackage('gember/serializer-symfony', [ErrorType::UNUSED_DEPENDENCY])
-    ->ignoreErrorsOnPackage('symfony/property-access', [ErrorType::UNUSED_DEPENDENCY]);
+    ->ignoreErrorsOnPackage('symfony/property-access', [ErrorType::UNUSED_DEPENDENCY])
+    ->ignoreUnknownFunctions(['Symfony\Component\DependencyInjection\Loader\Configurator\service']);

--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,10 @@
     "require": {
         "php": "^8.3",
         "ext-pcntl": "*",
-        "gember/event-sourcing": "^0.15",
+        "gember/event-sourcing": "^0.16",
         "gember/identity-generator-symfony": "^0.12",
         "gember/message-bus-symfony": "^0.12",
-        "gember/rdbms-event-store-doctrine-dbal": "^0.13",
+        "gember/rdbms-event-store-doctrine-dbal": "^0.14",
         "gember/serializer-symfony": "^0.12",
         "symfony/config": "^7.1|^7.2|^8.0",
         "symfony/console": "^7.1|^7.2|^8.0",

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     ],
     "require": {
         "php": "^8.3",
+        "ext-pcntl": "*",
         "gember/event-sourcing": "^0.15",
         "gember/identity-generator-symfony": "^0.12",
         "gember/message-bus-symfony": "^0.12",

--- a/config/outbox_services.yaml
+++ b/config/outbox_services.yaml
@@ -1,0 +1,88 @@
+services:
+  _defaults:
+    public: false
+
+  # Transaction manager (shared Doctrine connection)
+  gember.event_sourcing.outbox.transactional:
+    class: Gember\RdbmsEventStoreDoctrineDbal\Transaction\DoctrineDbalTransactional
+    arguments:
+      - '@gember.doctrine.dbal.connection'
+
+  # Outbox store
+  gember.event_sourcing.outbox.outbox_store:
+    class: Gember\EventSourcing\Outbox\Rdbms\RdbmsOutboxStore
+    arguments:
+      - '@gember.event_sourcing.outbox.rdbms.rdbms_outbox_repository'
+      - '@gember.event_sourcing.util.serialization.serializer.serializer'
+      - '@gember.event_sourcing.util.generator.identity.identity_generator'
+      - '@gember.event_sourcing.util.time.clock.clock'
+
+  # RDBMS outbox repository (same connection = same transaction)
+  gember.event_sourcing.outbox.rdbms.rdbms_outbox_repository:
+    class: Gember\RdbmsEventStoreDoctrineDbal\Outbox\DoctrineDbalRdbmsOutboxRepository
+    arguments:
+      - '@gember.doctrine.dbal.connection'
+      - '@gember.event_sourcing.outbox.table_schema.outbox_table_schema'
+      - '@gember.event_sourcing.outbox.doctrine_dbal_rdbms_outbox_factory'
+
+  gember.event_sourcing.outbox.table_schema.outbox_table_schema:
+    class: Gember\RdbmsEventStoreDoctrineDbal\Outbox\TableSchema\OutboxTableSchema
+    factory: [
+      Gember\RdbmsEventStoreDoctrineDbal\Outbox\TableSchema\OutboxTableSchemaFactory,
+      'createDefault'
+    ]
+
+  gember.event_sourcing.outbox.doctrine_dbal_rdbms_outbox_factory:
+    class: Gember\RdbmsEventStoreDoctrineDbal\Outbox\DoctrineDbalRdbmsOutboxFactory
+
+  # Outbox bus implementations
+  gember.event_sourcing.outbox.bus.outbox_event_bus:
+    class: Gember\EventSourcing\Outbox\Bus\OutboxEventBus
+    arguments:
+      - '@gember.event_sourcing.outbox.outbox_store'
+
+  gember.event_sourcing.outbox.bus.outbox_command_bus:
+    class: Gember\EventSourcing\Outbox\Bus\OutboxCommandBus
+    arguments:
+      - '@gember.event_sourcing.outbox.outbox_store'
+
+  # Transactional decorators
+  gember.event_sourcing.outbox.transactional_use_case_repository:
+    class: Gember\EventSourcing\Repository\Transactional\TransactionalUseCaseRepositoryDecorator
+    #decorates: gember.event_sourcing.repository.use_case_repository
+    arguments:
+      - '@.inner'
+      - '@gember.event_sourcing.outbox.transactional'
+
+  gember.event_sourcing.outbox.transactional_saga_event_executor:
+    class: Gember\EventSourcing\Saga\Transactional\TransactionalSagaEventExecutorDecorator
+    #decorates: gember.event_sourcing.saga.saga_event_executor
+    decoration_priority: -10
+    arguments:
+      - '@.inner'
+      - '@gember.event_sourcing.outbox.transactional'
+
+  # Processor (uses REAL bus implementations for actual dispatch)
+  Gember\EventSourcing\Outbox\Processor\OutboxProcessor:
+    class: Gember\EventSourcing\Outbox\Processor\Default\DefaultOutboxProcessor
+    arguments:
+      - '@gember.event_sourcing.outbox.outbox_store'
+      - '@gember.event_sourcing.outbox.processor.real_event_bus'
+      - '@gember.event_sourcing.outbox.processor.real_command_bus'
+      - '@gember.psr.log.logger_interface'
+
+  gember.event_sourcing.outbox.processor.real_event_bus:
+    class: Gember\MessageBusSymfony\SymfonyEventBus
+    arguments:
+      - '@gember.symfony.component.messenger.message_bus.event_bus'
+
+  gember.event_sourcing.outbox.processor.real_command_bus:
+    class: Gember\MessageBusSymfony\SymfonyCommandBus
+    arguments:
+      - '@gember.symfony.component.messenger.message_bus.command_bus'
+
+  # Console command
+  Gember\EventSourcingSymfonyBundle\Command\ProcessOutboxCommand:
+    arguments:
+      - '@Gember\EventSourcing\Outbox\Processor\OutboxProcessor'
+    tags: ['console.command']

--- a/rector.php
+++ b/rector.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 use Rector\CodeQuality\Rector\FuncCall\RemoveSoleValueSprintfRector;
 use Rector\CodeQuality\Rector\FuncCall\UnwrapSprintfOneArgumentRector;
 use Rector\CodeQuality\Rector\FunctionLike\SimplifyUselessVariableRector;
-use Rector\CodingStyle\Rector\FuncCall\CountArrayToEmptyArrayComparisonRector;
 use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\Array_\RemoveDuplicatedArrayKeyRector;
 use Rector\DeadCode\Rector\Cast\RecastingRemovalRector;
@@ -44,7 +43,6 @@ $config = RectorConfig::configure()
         PrivatizeFinalClassMethodRector::class,
         UnwrapSprintfOneArgumentRector::class,
         RemoveSoleValueSprintfRector::class,
-        CountArrayToEmptyArrayComparisonRector::class,
         // See withConfiguredRule below for more
 
         // Misc - Deadcode

--- a/src/Command/ProcessOutboxCommand.php
+++ b/src/Command/ProcessOutboxCommand.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gember\EventSourcingSymfonyBundle\Command;
+
+use Gember\EventSourcing\Outbox\Processor\OutboxProcessor;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Command\SignalableCommandInterface;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'gember:outbox:process',
+    description: 'Process pending outbox messages',
+)]
+final class ProcessOutboxCommand extends Command implements SignalableCommandInterface
+{
+    private bool $shouldStop = false;
+
+    public function __construct(
+        private readonly OutboxProcessor $outboxProcessor,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption('limit', 'l', InputOption::VALUE_REQUIRED, 'Max messages to process per batch', 100);
+        $this->addOption('watch', 'w', InputOption::VALUE_OPTIONAL, 'Continuously poll for messages with interval in milliseconds', false);
+        $this->addOption('memory-limit', null, InputOption::VALUE_REQUIRED, 'Memory limit (e.g., 128M)');
+        $this->addOption('time-limit', null, InputOption::VALUE_REQUIRED, 'Time limit in seconds');
+    }
+
+    /**
+     * @return list<int>
+     */
+    public function getSubscribedSignals(): array
+    {
+        return [\SIGINT, \SIGTERM];
+    }
+
+    public function handleSignal(int $signal, int|false $previousExitCode = 0): int|false
+    {
+        $this->shouldStop = true;
+
+        return false;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        /** @var int|string $limit */
+        $limit = $input->getOption('limit');
+        $limit = (int) $limit;
+
+        /** @var string|bool $watch */
+        $watch = $input->getOption('watch');
+
+        $this->outboxProcessor->process(limit: $limit);
+
+        if ($watch === false) {
+            return Command::SUCCESS;
+        }
+
+        $intervalMs = (int) ($watch ?: 100);
+        $intervalUs = max($intervalMs, 10) * 1000;
+
+        /** @var string|null $memoryLimitOption */
+        $memoryLimitOption = $input->getOption('memory-limit');
+        $memoryLimit = $memoryLimitOption !== null ? $this->parseMemoryLimit($memoryLimitOption) : null;
+
+        /** @var string|null $timeLimitOption */
+        $timeLimitOption = $input->getOption('time-limit');
+        $timeLimit = $timeLimitOption !== null ? (int) $timeLimitOption : null;
+
+        $startTime = time();
+
+        while (!$this->shouldStop) {
+            usleep($intervalUs);
+
+            $this->outboxProcessor->process(limit: $limit);
+
+            if ($memoryLimit !== null && memory_get_usage(true) >= $memoryLimit) {
+                $output->writeln('Memory limit reached, stopping.');
+                break;
+            }
+
+            if ($timeLimit !== null && (time() - $startTime) >= $timeLimit) {
+                $output->writeln('Time limit reached, stopping.');
+                break;
+            }
+        }
+
+        return Command::SUCCESS;
+    }
+
+    private function parseMemoryLimit(string $limit): int
+    {
+        $limit = strtoupper(trim($limit));
+        $value = (int) $limit;
+
+        return match (true) {
+            str_ends_with($limit, 'G') => $value * 1024 * 1024 * 1024,
+            str_ends_with($limit, 'M') => $value * 1024 * 1024,
+            str_ends_with($limit, 'K') => $value * 1024,
+            default => $value,
+        };
+    }
+}

--- a/src/Command/ProcessOutboxCommand.php
+++ b/src/Command/ProcessOutboxCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Gember\EventSourcingSymfonyBundle\Command;
 
 use Gember\EventSourcing\Outbox\Processor\OutboxProcessor;
+use Override;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Command\SignalableCommandInterface;
@@ -37,11 +38,13 @@ final class ProcessOutboxCommand extends Command implements SignalableCommandInt
     /**
      * @return list<int>
      */
+    #[Override]
     public function getSubscribedSignals(): array
     {
         return [\SIGINT, \SIGTERM];
     }
 
+    #[Override]
     public function handleSignal(int $signal, int|false $previousExitCode = 0): int|false
     {
         $this->shouldStop = true;

--- a/src/GemberEventSourcingBundle.php
+++ b/src/GemberEventSourcingBundle.php
@@ -13,6 +13,7 @@ use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\HttpKernel\Bundle\AbstractBundle;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 use Override;
 use ReflectionMethod;
 
@@ -115,6 +116,18 @@ final class GemberEventSourcingBundle extends AbstractBundle
                         ->scalarNode('logger')->end()
                     ->end()
                 ->end()
+                ->arrayNode('dispatch')
+                    ->children()
+                        ->enumNode('strategy')
+                            ->values(['direct', 'outbox'])
+                            ->defaultValue('direct')
+                        ->end()
+                        ->integerNode('max_retries')
+                            ->defaultValue(5)
+                            ->min(1)
+                        ->end()
+                    ->end()
+                ->end()
             ->end();
     }
 
@@ -213,6 +226,31 @@ final class GemberEventSourcingBundle extends AbstractBundle
                 'gember.psr.log.logger_interface',
                 ltrim($config['logging']['logger'], '@'),
             );
+        }
+
+        if (($config['dispatch']['strategy'] ?? 'direct') === 'outbox') {
+            $container->import(__DIR__ . '/../config/outbox_services.yaml');
+
+            // Replace event bus with outbox variant
+            $services->get('gember.event_sourcing.util.messaging.message_bus.event_bus')
+                ->class(\Gember\EventSourcing\Outbox\Bus\OutboxEventBus::class)
+                ->args([service('gember.event_sourcing.outbox.outbox_store')]);
+
+            // Replace command bus with outbox variant
+            $services->get('gember.event_sourcing.util.messaging.message_bus.command_bus')
+                ->class(\Gember\EventSourcing\Outbox\Bus\OutboxCommandBus::class)
+                ->args([service('gember.event_sourcing.outbox.outbox_store')]);
+
+            // Activate transactional decorators
+            $services->get('gember.event_sourcing.outbox.transactional_use_case_repository')
+                ->decorate('gember.event_sourcing.repository.use_case_repository');
+
+            $services->get('gember.event_sourcing.outbox.transactional_saga_event_executor')
+                ->decorate('gember.event_sourcing.saga.saga_event_executor');
+
+            // Configure max retries
+            $services->get(\Gember\EventSourcing\Outbox\Processor\OutboxProcessor::class)
+                ->arg('$maxRetries', $config['dispatch']['max_retries'] ?? 5);
         }
 
         $builder->registerAttributeForAutoconfiguration(


### PR DESCRIPTION
The transactional outbox pattern requires framework-level wiring to swap bus implementations, activate transactional decorators, and register the background processor. This PR adds a single configuration toggle that handles all of it.

When `dispatch.strategy` is set to `outbox`, the bundle replaces the event bus and command bus with outbox variants that write to the outbox table instead of dispatching. Transactional decorators wrap the use case repository and saga event executor to ensure atomicity. The outbox processor and its console command are registered for background dispatching.

The console command supports continuous polling via `--watch`, graceful shutdown on SIGTERM/SIGINT, and `--memory-limit`/`--time-limit` for production deployments where a process manager restarts the worker on exit.

Depends on GemberPHP/event-sourcing#87.

## Changes

- Add `dispatch.strategy` config option (`direct` or `outbox`, default `direct`)
- Add `dispatch.max_retries` config option (default `5`) for dead-letter threshold
- Add `config/outbox_services.yaml` with all outbox service definitions, imported conditionally
- Add `gember:outbox:process` console command with `--watch`, `--limit`, `--memory-limit`, `--time-limit` options and graceful shutdown
- Wire outbox bus replacements and transactional decorators when outbox strategy is active
- Remove deprecated `CountArrayToEmptyArrayComparisonRector` rule