### PR TITLE
Add snapshot service wiring and configuration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,10 @@
     "require": {
         "php": "^8.3",
         "ext-pcntl": "*",
-        "gember/event-sourcing": "^0.16",
+        "gember/event-sourcing": "^0.17",
         "gember/identity-generator-symfony": "^0.12",
         "gember/message-bus-symfony": "^0.12",
-        "gember/rdbms-event-store-doctrine-dbal": "^0.14",
+        "gember/rdbms-event-store-doctrine-dbal": "^0.15",
         "gember/serializer-symfony": "^0.12",
         "symfony/config": "^7.1|^7.2|^8.0",
         "symfony/console": "^7.1|^7.2|^8.0",

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -268,6 +268,12 @@ services:
       - '@gember.event_sourcing.resolver.common.domain_tag.attribute.attribute_domain_tag_resolver'
       - '@gember.event_sourcing.resolver.use_case.default.command_handler.command_handler_resolver'
       - '@gember.event_sourcing.resolver.use_case.default.event_subscriber.event_subscriber_resolver'
+      - '@gember.event_sourcing.resolver.use_case.default.snapshot.snapshot_resolver'
+
+  gember.event_sourcing.resolver.use_case.default.snapshot.snapshot_resolver:
+    class: Gember\EventSourcing\Resolver\UseCase\Default\Snapshot\Attribute\AttributeSnapshotResolver
+    arguments:
+      - '@gember.event_sourcing.util.attribute.resolver.attribute_resolver'
 
   gember.event_sourcing.resolver.use_case.cached.cached_use_case_resolver_decorator:
     class: Gember\EventSourcing\Resolver\UseCase\Cached\CachedUseCaseResolverDecorator
@@ -434,3 +440,56 @@ services:
       - '@gember.psr.log.logger_interface'
 
   gember.psr.log.logger_interface: '@logger'
+
+  # Snapshot store
+  gember.rdbms_event_store_doctrine_dbal.snapshot.table_schema.snapshot_store_table_schema:
+    class: Gember\RdbmsEventStoreDoctrineDbal\Snapshot\TableSchema\SnapshotStoreTableSchema
+    factory: [
+      Gember\RdbmsEventStoreDoctrineDbal\Snapshot\TableSchema\SnapshotTableSchemaFactory,
+      'createDefault'
+    ]
+
+  gember.event_store.snapshot.rdbms_snapshot_store_repository:
+    class: Gember\RdbmsEventStoreDoctrineDbal\Snapshot\DoctrineDbalRdbmsSnapshotStoreRepository
+    arguments:
+      - '@gember.doctrine.dbal.connection'
+      - '@gember.rdbms_event_store_doctrine_dbal.snapshot.table_schema.snapshot_store_table_schema'
+
+  gember.event_sourcing.snapshot.snapshot_store:
+    class: Gember\EventSourcing\Snapshot\Rdbms\RdbmsSnapshotStore
+    arguments:
+      - '@gember.event_store.snapshot.rdbms_snapshot_store_repository'
+
+  # Snapshot policies
+  gember.event_sourcing.snapshot.policy.after_events:
+    class: Gember\EventSourcing\Snapshot\Policy\AfterEventsSnapshotPolicy
+    tags: ['gember.snapshot.policy']
+
+  gember.event_sourcing.snapshot.policy.after_sourcing_time:
+    class: Gember\EventSourcing\Snapshot\Policy\AfterSourcingTimeSnapshotPolicy
+    tags: ['gember.snapshot.policy']
+
+  gember.event_sourcing.snapshot.policy.on_events:
+    class: Gember\EventSourcing\Snapshot\Policy\OnEventsSnapshotPolicy
+    tags: ['gember.snapshot.policy']
+
+  # Snapshot logging decorator
+  gember.event_sourcing.snapshot.loggable.loggable_snapshot_store_decorator:
+    class: Gember\EventSourcing\Snapshot\Loggable\LoggableSnapshotStoreDecorator
+    decorates: gember.event_sourcing.snapshot.snapshot_store
+    arguments:
+      - '@.inner'
+      - '@gember.psr.log.logger_interface'
+
+  # Snapshot decorator
+  gember.event_sourcing.repository.snapshot.snapshot_use_case_repository_decorator:
+    class: Gember\EventSourcing\Repository\Snapshot\SnapshotUseCaseRepositoryDecorator
+    #decorates: gember.event_sourcing.repository.use_case_repository
+    arguments:
+      - '@.inner'
+      - '@Gember\EventSourcing\EventStore\EventStore'
+      - '@gember.event_sourcing.resolver.use_case.use_case_resolver'
+      - '@gember.event_sourcing.snapshot.snapshot_store'
+      - '@gember.event_sourcing.util.serialization.serializer.serializer'
+      - !tagged_iterator gember.snapshot.policy
+      - '@gember.psr.log.logger_interface'

--- a/src/GemberEventSourcingBundle.php
+++ b/src/GemberEventSourcingBundle.php
@@ -6,6 +6,7 @@ namespace Gember\EventSourcingSymfonyBundle;
 
 use Gember\EventSourcing\Saga\Attribute\SagaEventSubscriber;
 use Gember\EventSourcing\Saga\SagaEventHandler;
+use Gember\EventSourcing\Snapshot\Policy\SnapshotPolicy;
 use Gember\EventSourcing\UseCase\Attribute\DomainCommandHandler;
 use Gember\EventSourcing\UseCase\CommandHandler\UseCaseCommandHandler;
 use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
@@ -114,6 +115,11 @@ final class GemberEventSourcingBundle extends AbstractBundle
                 ->arrayNode('logging')
                     ->children()
                         ->scalarNode('logger')->end()
+                    ->end()
+                ->end()
+                ->arrayNode('snapshot')
+                    ->children()
+                        ->booleanNode('enabled')->defaultFalse()->end()
                     ->end()
                 ->end()
                 ->arrayNode('dispatch')
@@ -228,6 +234,23 @@ final class GemberEventSourcingBundle extends AbstractBundle
             );
         }
 
+        // Snapshot decorator must be activated BEFORE the transactional decorator (outbox).
+        // Symfony's later decorates() calls wrap earlier ones, resulting in:
+        // Transactional(Snapshot(EventSourced)) — snapshot save happens inside the transaction.
+        if ($config['snapshot']['enabled'] ?? false) {
+            $services->get('gember.event_sourcing.repository.snapshot.snapshot_use_case_repository_decorator')
+                ->decorate('gember.event_sourcing.repository.use_case_repository');
+        } else {
+            $services->remove('gember.event_store.snapshot.rdbms_snapshot_store_repository');
+            $services->remove('gember.event_sourcing.snapshot.snapshot_store');
+            $services->remove('gember.rdbms_event_store_doctrine_dbal.snapshot.table_schema.snapshot_store_table_schema');
+            $services->remove('gember.event_sourcing.snapshot.policy.after_events');
+            $services->remove('gember.event_sourcing.snapshot.policy.after_sourcing_time');
+            $services->remove('gember.event_sourcing.snapshot.policy.on_events');
+            $services->remove('gember.event_sourcing.snapshot.loggable.loggable_snapshot_store_decorator');
+            $services->remove('gember.event_sourcing.repository.snapshot.snapshot_use_case_repository_decorator');
+        }
+
         if (($config['dispatch']['strategy'] ?? 'direct') === 'outbox') {
             $container->import(__DIR__ . '/../config/outbox_services.yaml');
 
@@ -286,5 +309,8 @@ final class GemberEventSourcingBundle extends AbstractBundle
                     ]);
             },
         );
+
+        $builder->registerForAutoconfiguration(SnapshotPolicy::class)
+            ->addTag('gember.snapshot.policy');
     }
 }


### PR DESCRIPTION
## Summary

Wire the snapshotting services into the Symfony bundle with a configuration option to enable/disable.

## Why

The snapshotting feature in `gember/event-sourcing` and `gember/rdbms-event-store-doctrine-dbal` requires DI wiring to integrate with Symfony applications. This PR makes snapshotting opt-in via a single config flag, following the same pattern as the outbox feature.

## What

### Service definitions

Added to `config/services.yaml`:

- **Snapshot store** — `RdbmsSnapshotStore` backed by `DoctrineDbalRdbmsSnapshotStoreRepository` with `SnapshotStoreTableSchema`
- **Snapshot policies** — Three built-in policies (`AfterEventsSnapshotPolicy`, `AfterSourcingTimeSnapshotPolicy`, `OnEventsSnapshotPolicy`) tagged with `gember.snapshot.policy`
- **Snapshot resolver** — `AttributeSnapshotResolver` wired as 4th argument to `DefaultUseCaseResolver`
- **Snapshot decorator** — `SnapshotUseCaseRepositoryDecorator` wrapping the use case repository
- **Loggable decorator** — `LoggableSnapshotStoreDecorator` for structured logging

### Configuration

```yaml
gember_event_sourcing:
    snapshot:
        enabled: true  # default: false
```

When enabled, the snapshot decorator is activated on the use case repository. When disabled, all snapshot-related services are removed from the container.

### Decorator ordering

The snapshot decorator is activated **before** the transactional decorator (outbox), ensuring snapshot saves happen inside the transaction boundary. This ordering is documented in the code.

### Autoconfiguration

Custom `SnapshotPolicy` implementations are automatically tagged with `gember.snapshot.policy` via `registerForAutoconfiguration()`, so they're picked up by the `!tagged_iterator` without manual configuration.

> **Note:** This PR depends on the snapshotting changes in `gember/event-sourcing` and `gember/rdbms-event-store-doctrine-dbal`. The dependency analyser will report unknown classes until those packages are released.